### PR TITLE
add hyperlinks

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -24,23 +24,45 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     />
 
     <p class="text-lg leading-relaxed text-gray-700 mb-4">
-      I'm Head of Product at DualEntry, the ERP built from the ground up to solve what legacy
-      systems can't. We're the first AI-native ERP built after ChatGPT — designed for how finance
-      teams actually work today, not retrofitted for it. I lead our product management, design, and
-      education functions, and I'm fired up about what we're building alongside a team backed by
-      Khosla Ventures and Lightspeed, who co-led our $90M Series A, with GV (Google Ventures),
-      Contrary, and Vesey Ventures.
+      I'm Head of Product at <a
+        href="https://www.dualentry.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-black underline hover:opacity-70">DualEntry</a
+      >, the ERP built from the ground up to solve what legacy systems can't. We're the first
+      AI-native ERP built after ChatGPT — designed for how finance teams actually work today, not
+      retrofitted for it. I lead our product management, design, and education functions, and I'm
+      fired up about what we're building alongside a team backed by <a
+        href="https://www.khoslaventures.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-black underline hover:opacity-70">Khosla Ventures</a
+      > and <a
+        href="https://lsvp.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-black underline hover:opacity-70">Lightspeed</a
+      >, who co-led our $90M Series A, with <a
+        href="https://www.gv.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-black underline hover:opacity-70">GV (Google Ventures)</a
+      >, Contrary, and Vesey Ventures.
     </p>
 
     <p class="text-lg leading-relaxed text-gray-700 mb-4">
-      Previously, I spent 8.5 incredible years at Cockroach Labs, where I helped scale CockroachDB
-      from pre-revenue to $100M+ ARR and category leadership. I led cross-functional teams of 50+
-      driving our Application and Database Ecosystem, pioneered our evolution into the AI-powered
-      application stack, and owned CockroachDB's integration with the broader application ecosystem
-      — observability, disaster recovery, change data capture (CDC), streaming, and migration
-      workflows across hybrid and cloud environments. I also led pricing and packaging strategy,
-      aligning product value with business outcomes through a data-driven, iterative approach to
-      product-market-price fit.
+      Previously, I spent 8.5 incredible years at <a
+        href="https://www.cockroachlabs.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-black underline hover:opacity-70">Cockroach Labs</a
+      >, where I helped scale CockroachDB from pre-revenue to $100M+ ARR and category leadership. I
+      led cross-functional teams of 50+ driving our Application and Database Ecosystem, pioneered
+      our evolution into the AI-powered application stack, and owned CockroachDB's integration with
+      the broader application ecosystem — observability, disaster recovery, change data capture
+      (CDC), streaming, and migration workflows across hybrid and cloud environments. I also led
+      pricing and packaging strategy, aligning product value with business outcomes through a
+      data-driven, iterative approach to product-market-price fit.
     </p>
 
     <p class="text-lg leading-relaxed text-gray-700 mb-4">


### PR DESCRIPTION
## Summary
- Adds hyperlinks on the About page for DualEntry, Cockroach Labs, Khosla Ventures, Lightspeed, and GV
- Matches existing link styling (`text-black underline hover:opacity-70`, opens in new tab)

## Test plan
- [ ] Verify all five links open correct destinations in a new tab
- [ ] Confirm link styling matches existing links on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)