### PR TITLE
fix(deps): override devalue to ^5.8.1 to patch DoS vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5064,9 +5064,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/devlop": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "engines": {
     "node": ">=22.12.0"
   },
+  "overrides": {
+    "devalue": "^5.8.1"
+  },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- Adds an `overrides` entry pinning `devalue` to `^5.8.1` so the transitive dep from Astro is no longer affected by [GHSA-77vg-94rm-hx3p](https://github.com/advisories/GHSA-77vg-94rm-hx3p) (DoS via sparse array deserialization).
- Unblocks the Security Scan workflow, which currently fails on `main` and on every open PR (including #81).

## Test plan
- [x] `npm install` resolves devalue to 5.8.1 (`npm ls devalue` confirms `astro@6.3.1 -> devalue@5.8.1`)
- [x] `npm audit --production --audit-level=high` reports `found 0 vulnerabilities`
- [x] `npm run build` completes successfully (30 pages built)
- [ ] CI: Security Scan passes
- [ ] After merge: comment `@dependabot rebase` on #81 to pick up the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)