### PR TITLE
chore: ignore TypeScript major-version bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,15 @@ updates:
           - 'minor'
           - 'patch'
 
+    # Ignore updates that the toolchain can't yet support.
+    # TypeScript 7.x is the native (Go) compiler; @typescript-eslint and
+    # @astrojs/check don't support it yet, so major bumps break lint and
+    # astro check. Stay on 6.x until the ecosystem catches up.
+    ignore:
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
+
     # Customize PR settings
     commit-message:
       prefix: 'chore(deps)'


### PR DESCRIPTION
## Why

Dependabot opened #106 to bump TypeScript 6.0.3 → 7.0.2. TypeScript 7.x is the new **native (Go) compiler** with breaking internal-API changes, and the project's toolchain doesn't support it yet:

| Tool | Latest version | Max TS supported |
|------|----------------|------------------|
| `@typescript-eslint` | 8.63.0 | `>=4.8.4 <6.1.0` |
| `@astrojs/check` / language-server | 0.9.9 | `^5.0.0 \|\| ^6.0.0` |

As a result, TS 7 crashes both CI checks:
- **Lint & Type Check** → `Cannot read properties of undefined (reading 'Cjs')`
- **Astro Check** → `Cannot read properties of undefined (reading 'fileExists')`

There's no compatible tooling release to upgrade to, so the bump can't pass CI.

## What

Add a Dependabot `ignore` rule for TypeScript **major** version updates. The project stays on 6.x; minor/patch 6.x updates still flow through. Remove the rule once `@typescript-eslint` and `@astrojs/check` ship TS 7 support.

Closes #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)